### PR TITLE
Add Linux.conf.au 2018

### DIFF
--- a/app/data/confs.json
+++ b/app/data/confs.json
@@ -430,5 +430,15 @@
     "numberOfWomen":5,
     "source":"http://2016.jsconfau.com/",
     "Notes":""
+  },
+  {
+    "name": "Linux.conf.au",
+    "location": "Sydney, Australia",
+    "year": "2018",
+    "totalSpeakers": 154,
+    "numberOfWomen": 36,
+    "numberOfOtherGenders": 4,
+    "source": "https://rego.linux.conf.au/schedule/",
+    "Notes": ""
   }
 ]


### PR DESCRIPTION
This adds statistics for Linux.conf.au 2018, which is being held next week in Sydney. I was originally going through each speaker bio and looking for pronouns, but near the end I just guessed the ones that were very likely to be a particular gender (e.g. people called Paul or John) because, well, there's 154 speakers to go through.

Since there are 4 speakers at LCA who don't identify as either male or female from what I could tell, I also added a `numberOfOtherGenders` key to the JSON object, so that if you decide to add support for counting non-binary/other-gender speakers to the web app, there's one data point already there at least.